### PR TITLE
Fix startup.sh path & clarify README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # uptime_monitor
 
 Simple CLI to log HTTP status, cache hits, TTFB, and full load time.
-Saves per-site tables in `website_stats.db`.
-Edit paths in `monitor.py` or run via `startup.sh`.
+The monitor stores `website_stats.db` and `urls.txt` in the directory it is run from.
 
 ## quick start
 ```

--- a/startup.sh
+++ b/startup.sh
@@ -1,4 +1,3 @@
 #!/bin/sh
 python3 -m pip install -r requirements.txt
-mkdir -p /home/ffunk/PROJECTS/UPTIME_MONITOR
 [ -f urls.txt ] || echo 'https://funkpd.com' > urls.txt


### PR DESCRIPTION
## Summary
- drop hard-coded workspace from `startup.sh`
- clarify that the monitor stores `urls.txt` and the database in the current directory

## Testing
- `python3 monitor.py`

------
https://chatgpt.com/codex/tasks/task_e_684126a4f250832597835c030bc550bf